### PR TITLE
Update Météo-France lovelace card link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ _Home Assitant supporte dès la première installation de nombreux équipement o
 ### Lovelace Custom cards
 
 - [Linky](https://github.com/royto/linky-card) - Une carte pour Lovelace vous permettant d'afficher les informations de votre compteur Linky.
-- [MétéoFrance](https://github.com/Imbuzi/meteo-france-weather-card) - Une carte pour Lovelace vous permettant d'afficher toutes les informations disponible avec l'intégration officielle Météo France (prévision, pluie à 1 heure, vigilance météo).
+- [MétéoFrance](https://github.com/hacf-fr/lovelace-meteofrance-weather-card) - Une carte pour Lovelace vous permettant d'afficher toutes les informations disponible avec l'intégration officielle Météo France (prévision, pluie à 1 heure, vigilance météo).
 
 ## Discussions et entraides
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ _Home Assitant supporte dès la première installation de nombreux équipements 
 ### Cartes Personnalisées pour l'interface Lovelace (Lovelace Custom cards)
 
 - [Linky](https://github.com/royto/linky-card) - Une carte pour Lovelace vous permettant d'afficher les informations de votre compteur Linky.
-- [MétéoFrance](https://github.com/hacf-fr/lovelace-meteofrance-weather-card) - Une carte pour Lovelace vous permettant d'afficher toutes les informations disponible avec l'intégration officielle Météo France (prévision, pluie à 1 heure, vigilance météo).
+- [MétéoFrance](https://github.com/hacf-fr/lovelace-meteofrance-weather-card) - Une carte pour Lovelace vous permettant d'afficher toutes les informations disponibles avec l'intégration officielle Météo France (prévision, pluie à 1 heure, vigilance météo).
 
 ## Discussions et entraides
 


### PR DESCRIPTION
Initial repository (https://github.com/Imbuzi/meteo-france-weather-card) seems not to be maintained. So link updated with the rework done by HACF community members.