### PR TITLE
Fix static site building.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.1.2
 mkdocs-material==6.1.3
-mkdocs-simple-plugin==0.1.8
+mkdocs-simple-plugin==0.2
 mdx_truly_sane_lists==1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: Awesome Francophone Home Assistant
-site_url: "http://awesome.hacf.fr/"
+site_url: "https://awesome.hacf.fr/"
 site_description: "Une liste de liens super utiles pour Home Assistant en français."
 site_author: "HACF"
 copyright: "Copyright 2020 - HACF. Creative Commons Zero v1.0 Universal."


### PR DESCRIPTION
Bump mkdocs-simple-plugin after discussion on issue: https://github.com/athackst/mkdocs-simple-plugin/issues/57
-> CNAME is now it the root folder of the generated static site.