### PR TITLE
Ajoute un mode sombre en fonction des paramètres de l'OS de l'utilisateur

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,9 @@ theme:
   name: material
   language: fr
   palette:
+    scheme: preference
     primary: white
-    accent: indigo
+    accent: red
   logo: "https://hacf.fr/wp-content/uploads/logo@2x.png"
   features:
     - navigation.tabs


### PR DESCRIPTION
contribut à #58 

L'ajout d'un switch sera possible plus tard. La fonction est disponible mais réservée pour le moment au "Insider" et donc payant.