### PR TITLE
Lance le CI uniquement sur la branche main

### DIFF
--- a/.github/workflows/awesome.yml
+++ b/.github/workflows/awesome.yml
@@ -1,6 +1,8 @@
 name: Lint Awesome List
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: 0 12 * * *


### PR DESCRIPTION
Pour éviter les double CI dans les PR